### PR TITLE
config: quote_style default to :single

### DIFF
--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -4,7 +4,7 @@ module Rufo::Settings
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [true, false],
-    quote_style: [:double, :single],
+    quote_style: [:single, :double],
     space_inside_hash: [false, true],
     includes: nil,
     excludes: nil,


### PR DESCRIPTION
**Context**
- CREMA uses single quote wherever possible

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
