### PR TITLE
feat: space_inside_lambda

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2655,7 +2655,11 @@ class Rufo::Formatter
     if void_exps?(body)
       consume_space
       consume_token :on_tlambeg
-      consume_space
+      if space_inside_lambda
+        consume_space
+      else
+        skip_space_or_newline
+      end
       consume_token :on_rbrace
       return
     end
@@ -2671,9 +2675,17 @@ class Rufo::Formatter
       if current_token_line == closing_brace_token[0][0]
         consume_token :on_tlambeg
 
-        consume_space
+        if space_inside_lambda
+          consume_space
+        else
+          skip_space_or_newline
+        end
         visit_exps body, with_lines: false
-        consume_space
+        if space_inside_lambda
+          consume_space
+        else
+          skip_space_or_newline
+        end
 
         consume_token :on_rbrace
         return

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -6,6 +6,7 @@ module Rufo::Settings
     trailing_commas: [true, false],
     quote_style: [:single, :double],
     space_inside_hash: [false, true],
+    space_inside_lambda: [false, true],
     includes: nil,
     excludes: nil,
   }


### PR DESCRIPTION
**Context**
- CREMA doesn't use space inside lambda
- Added settings space_inside_lambda, defaulting to false for CREMA

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
